### PR TITLE
Add datadev.sql to .gitignore for SQL Dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### SQL Dev ###
+datadev.sql


### PR DESCRIPTION
Se ha añadido en el archivo, para que no lea los archivos .sql.