### PR TITLE
Documentar entidades y endpoints de la API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,44 @@ curl http://localhost:8080/health/status
 
 ## Entidades de ejemplo
 
-El proyecto incluye modelos JPA de ejemplo con relaciones uno a uno:
+El proyecto incluye modelos JPA con relaciones entre usuarios, direcciones,
+órdenes y pagos:
 
 - `User`
 - `Role`
+- `Address`
+- `Order`
+- `Payment`
+
+## Endpoints principales
+
+Estos son los endpoints más relevantes que expone la API:
+
+- Salud:
+  - `GET /health/status`
+- Autenticación:
+  - `POST /auth/login`
+  - `POST /auth/register`
+  - `POST /auth/logout`
+- Usuarios:
+  - `GET /users`
+  - `GET /users/{id}`
+  - `POST /users`
+  - `PUT /users`
+  - `DELETE /users/{id}`
+  - `POST /users/ban/{id}`
+- Direcciones:
+  - `GET /address/{id}`
+  - `POST /address`
+  - `PUT /address`
+  - `DELETE /address/{id}`
+- Órdenes y pagos:
+  - `GET /orders/users/{id}`
+  - `GET /orders/{id}`
+  - `POST /orders/nextStatus`
+  - `POST /orders/{orderId}/payments`
+  - `GET /orders/{orderId}/payments/last`
+  - `POST /orders/payments/{paymentId}/nextStatus`
 
 ## Pruebas
 
@@ -53,4 +87,3 @@ Para ejecutar la suite de pruebas:
 ```bash
 mvn test
 ```
-


### PR DESCRIPTION
### Motivation
- Reflejar en la documentación los cambios traídos en `develop`: se añadieron modelos y funcionalidad relacionados con direcciones, órdenes y pagos, por lo que el `README.md` debe listar esas entidades y los endpoints principales.

### Description
- Se actualizó `README.md` para incluir las entidades `Address`, `Order` y `Payment` y añadir una sección `Endpoints principales` que documenta las rutas clave como `GET /health/status`, `POST /auth/login`, las rutas de usuarios (`/users`), direcciones (`/address`) y órdenes/pagos (`/orders`, `/orders/{orderId}/payments`, etc.).

### Testing
- No se ejecutaron pruebas automatizadas porque es un cambio de documentación (docs-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875116088883319cb4a7e8806a0fc0)