### PR TITLE
Add OrderAddresses model and OrderAddrResponseDTO with mapper

### DIFF
--- a/src/main/java/es/marcha/backend/dto/response/OrderAddrResponseDTO.java
+++ b/src/main/java/es/marcha/backend/dto/response/OrderAddrResponseDTO.java
@@ -1,0 +1,30 @@
+package es.marcha.backend.dto.response;
+
+import java.time.LocalDateTime;
+
+import es.marcha.backend.model.enums.AddressesType;
+import es.marcha.backend.model.order.Order;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+public class OrderAddrResponseDTO {
+    private long id;
+    private Order order;
+    private AddressesType type;
+    private String addressLine1;
+    private String addressLine2;
+    private String city;
+    private String state;
+    private String postalCode;
+    private String country;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/es/marcha/backend/mapper/OrderAddrMapper.java
+++ b/src/main/java/es/marcha/backend/mapper/OrderAddrMapper.java
@@ -1,0 +1,21 @@
+package es.marcha.backend.mapper;
+
+import es.marcha.backend.dto.response.OrderAddrResponseDTO;
+import es.marcha.backend.model.order.OrderAddresses;
+
+public class OrderAddrMapper {
+    public static OrderAddrResponseDTO toOrderAddressDTO(OrderAddresses orderAddress) {
+        return OrderAddrResponseDTO.builder()
+                .id(orderAddress.getId())
+                .order(orderAddress.getOrder())
+                .type(orderAddress.getType())
+                .addressLine1(orderAddress.getAddressLine1())
+                .addressLine2(orderAddress.getAddressLine2())
+                .city(orderAddress.getCity())
+                .state(orderAddress.getState())
+                .postalCode(orderAddress.getPostalCode())
+                .country(orderAddress.getCountry())
+                .createdAt(orderAddress.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/es/marcha/backend/model/order/OrderAddresses.java
+++ b/src/main/java/es/marcha/backend/model/order/OrderAddresses.java
@@ -1,0 +1,56 @@
+package es.marcha.backend.model.order;
+
+import java.time.LocalDateTime;
+
+import es.marcha.backend.model.enums.AddressesType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@Entity
+@Table(name = "order_addresses")
+public class OrderAddresses {
+    // Attribs
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
+    @ManyToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AddressesType type;
+    @Column(name = "address_line_1", nullable = false)
+    private String addressLine1;
+    @Column(name = "address_line_2")
+    private String addressLine2;
+    @Column(name = "city", nullable = false)
+    private String city;
+    @Column(name = "state", nullable = false)
+    private String state;
+    @Column(name = "posta_code", nullable = false)
+    private String postalCode;
+    @Column(name = "country", nullable = false)
+    private String country;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+}


### PR DESCRIPTION
Se ha creado la Entidad OrderAddresses, esto nos permitirá crear una tabla para que trabaje como snapshot y llevar un registor inmutable de las direcciones en las ordenes de pedidos. Orders.

Se ha creado la entidad, DTO y mapper.