### PR TITLE
feat(notification): Agregar 5 plantillas HTML de email

### DIFF
--- a/src/main/resources/templates/emails/support/ticket-admin.html
+++ b/src/main/resources/templates/emails/support/ticket-admin.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Arial", sans-serif;
+            background-color: #f3f3f3;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .email-wrapper {
+            width: 100%;
+            padding: 20px 0;
+            background-color: #f3f3f3;
+        }
+        .email-container {
+            max-width: 650px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #dc3545;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header img {
+            max-width: 120px;
+            margin-bottom: 10px;
+        }
+        .content {
+            padding: 30px 25px;
+        }
+        .content h2 {
+            color: #dc3545;
+            margin-top: 0;
+        }
+        .content p {
+            line-height: 1.6;
+            font-size: 15px;
+        }
+        .ticket-info {
+            background-color: #f8f9fa;
+            border-left: 4px solid #dc3545;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .ticket-info p {
+            margin: 5px 0;
+        }
+        .ticket-info strong {
+            color: #232f3e;
+        }
+        .user-info {
+            background-color: #e7f3ff;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .message-box {
+            background-color: #fff;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .priority-high {
+            background-color: #dc3545;
+            color: white;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        .priority-medium {
+            background-color: #ffc107;
+            color: #111;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        .priority-low {
+            background-color: #28a745;
+            color: white;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        .btn-manage-ticket {
+            display: inline-block;
+            background-color: #dc3545;
+            color: white !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 14px 28px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777777;
+            text-align: center;
+            padding: 15px 20px;
+            background-color: #f3f3f3;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-wrapper">
+        <div class="email-container">
+            <div class="header">
+                <img th:if="${hasLogo}" src="cid:logoImage" alt="Admin Dashboard" />
+                <h1>Nuevo ticket de soporte</h1>
+            </div>
+            <div class="content">
+                <p>Hola Admin,</p>
+                <p>Se ha creado un nuevo ticket de soporte que requiere atención:</p>
+
+                <div class="ticket-info">
+                    <p><strong>Número de ticket:</strong> <span th:text="${ticketNumber}">#12345</span></p>
+                    <p><strong>Asunto:</strong> <span th:text="${ticketSubject}">Problema con el pedido</span></p>
+                    <p><strong>Categoría:</strong> <span th:text="${ticketCategory}">Pedidos</span></p>
+                    <p>
+                        <strong>Prioridad:</strong> 
+                        <span th:class="${'priority-' + #strings.toLowerCase(ticketPriority)}" 
+                              th:text="${ticketPriority}">Alta</span>
+                    </p>
+                    <p><strong>Fecha de creación:</strong> <span th:text="${createdDate}">13/03/2026 14:30</span></p>
+                    <p><strong>Estado:</strong> <span th:text="${ticketStatus}">Abierto</span></p>
+                </div>
+
+                <div class="user-info">
+                    <p><strong>Información del cliente:</strong></p>
+                    <p><strong>Usuario:</strong> <span th:text="${userName}">Juan Pérez</span></p>
+                    <p><strong>Email:</strong> <span th:text="${userEmail}">juan@example.com</span></p>
+                    <p th:if="${orderId != null}">
+                        <strong>Pedido relacionado:</strong> <span th:text="${orderId}">#5678</span>
+                    </p>
+                </div>
+
+                <p><strong>Mensaje del cliente:</strong></p>
+                <div class="message-box">
+                    <p th:text="${userMessage}">
+                        Este es el mensaje inicial del cliente describiendo su problema o consulta.
+                    </p>
+                </div>
+
+                <a th:href="${adminTicketLink}" class="btn-manage-ticket">Gestionar ticket</a>
+
+                <p style="margin-top: 20px; font-size: 13px; color: #666;">
+                    Este email es una notificación automática del sistema de soporte.
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2026 Tu Empresa - Panel de Administración</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/emails/support/ticket-close.html
+++ b/src/main/resources/templates/emails/support/ticket-close.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Arial", sans-serif;
+            background-color: #f3f3f3;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .email-wrapper {
+            width: 100%;
+            padding: 20px 0;
+            background-color: #f3f3f3;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #28a745;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header img {
+            max-width: 120px;
+            margin-bottom: 10px;
+        }
+        .content {
+            padding: 30px 25px;
+        }
+        .content h2 {
+            color: #28a745;
+            margin-top: 0;
+        }
+        .content p {
+            line-height: 1.6;
+            font-size: 15px;
+        }
+        .ticket-info {
+            background-color: #f8f9fa;
+            border-left: 4px solid #28a745;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .ticket-info p {
+            margin: 5px 0;
+        }
+        .ticket-info strong {
+            color: #232f3e;
+        }
+        .resolution-box {
+            background-color: #d4edda;
+            border: 1px solid #c3e6cb;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .resolution-box .title {
+            font-weight: bold;
+            color: #155724;
+            margin-bottom: 10px;
+        }
+        .checkmark {
+            color: #28a745;
+            font-size: 48px;
+            text-align: center;
+            margin: 20px 0;
+        }
+        .survey-box {
+            background-color: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 20px 0;
+            text-align: center;
+        }
+        .btn-survey {
+            display: inline-block;
+            background-color: #ffc107;
+            color: #111 !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .btn-view-history {
+            display: inline-block;
+            background-color: #232f3e;
+            color: white !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 14px 28px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777777;
+            text-align: center;
+            padding: 15px 20px;
+            background-color: #f3f3f3;
+        }
+        .footer a {
+            color: #232f3e;
+            text-decoration: none;
+            margin: 0 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-wrapper">
+        <div class="email-container">
+            <div class="header">
+                <img th:if="${hasLogo}" src="cid:logoImage" alt="Tu Empresa" />
+                <h1>Ticket cerrado</h1>
+            </div>
+            <div class="content">
+                <div class="checkmark">&#10004;</div>
+                
+                <p style="text-align: center;">Hola <span th:text="${userName}">Usuario</span>,</p>
+                <p style="text-align: center;">Tu ticket de soporte ha sido cerrado exitosamente.</p>
+
+                <div class="ticket-info">
+                    <p><strong>Número de ticket:</strong> <span th:text="${ticketNumber}">#12345</span></p>
+                    <p><strong>Asunto:</strong> <span th:text="${ticketSubject}">Problema con el pedido</span></p>
+                    <p><strong>Fecha de creación:</strong> <span th:text="${createdDate}">10/03/2026</span></p>
+                    <p><strong>Fecha de cierre:</strong> <span th:text="${closedDate}">13/03/2026</span></p>
+                    <p><strong>Tiempo de resolución:</strong> <span th:text="${resolutionTime}">3 días</span></p>
+                    <p><strong>Cerrado por:</strong> <span th:text="${closedBy}">Equipo de Soporte</span></p>
+                </div>
+
+                <div class="resolution-box" th:if="${resolutionNotes != null}">
+                    <p class="title">Notas de resolución:</p>
+                    <p th:text="${resolutionNotes}">
+                        El problema ha sido resuelto satisfactoriamente. El pedido ha sido procesado 
+                        correctamente y se encuentra en camino.
+                    </p>
+                </div>
+
+                <p>Esperamos haber resuelto tu consulta satisfactoriamente. Si tienes alguna otra pregunta o problema, no dudes en contactarnos nuevamente.</p>
+
+                <div class="survey-box" th:if="${includeSurvey}">
+                    <p><strong>¿Cómo fue tu experiencia con nuestro soporte?</strong></p>
+                    <p style="font-size: 13px;">Tu opinión nos ayuda a mejorar nuestro servicio.</p>
+                    <a th:href="${surveyLink}" class="btn-survey">Calificar atención recibida</a>
+                </div>
+
+                <a th:href="${ticketHistoryLink}" class="btn-view-history">Ver historial completo</a>
+
+                <p style="margin-top: 30px; font-size: 13px; color: #666; text-align: center;">
+                    Este ticket ha sido archivado. Si necesitas ayuda con otro tema, 
+                    puedes crear un nuevo ticket desde tu panel de usuario.
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2026 Tu Empresa. Todos los derechos reservados.</p>
+            <p>
+                <a href="#">Términos</a> | 
+                <a href="#">Privacidad</a> | 
+                <a href="#">Ayuda</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/emails/support/ticket-update.html
+++ b/src/main/resources/templates/emails/support/ticket-update.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Arial", sans-serif;
+            background-color: #f3f3f3;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .email-wrapper {
+            width: 100%;
+            padding: 20px 0;
+            background-color: #f3f3f3;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #007bff;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header img {
+            max-width: 120px;
+            margin-bottom: 10px;
+        }
+        .content {
+            padding: 30px 25px;
+        }
+        .content h2 {
+            color: #007bff;
+            margin-top: 0;
+        }
+        .content p {
+            line-height: 1.6;
+            font-size: 15px;
+        }
+        .ticket-info {
+            background-color: #f8f9fa;
+            border-left: 4px solid #007bff;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .ticket-info p {
+            margin: 5px 0;
+        }
+        .ticket-info strong {
+            color: #232f3e;
+        }
+        .update-box {
+            background-color: #e7f3ff;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .update-box .author {
+            font-size: 13px;
+            color: #666;
+            margin-bottom: 10px;
+        }
+        .update-box .author strong {
+            color: #007bff;
+        }
+        .response-message {
+            background-color: #fff;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 15px;
+            margin-top: 10px;
+        }
+        .status-badge {
+            display: inline-block;
+            background-color: #007bff;
+            color: white;
+            padding: 4px 10px;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        .btn-view-ticket {
+            display: inline-block;
+            background-color: #f90;
+            color: #111 !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 14px 28px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777777;
+            text-align: center;
+            padding: 15px 20px;
+            background-color: #f3f3f3;
+        }
+        .footer a {
+            color: #232f3e;
+            text-decoration: none;
+            margin: 0 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-wrapper">
+        <div class="email-container">
+            <div class="header">
+                <img th:if="${hasLogo}" src="cid:logoImage" alt="Tu Empresa" />
+                <h1>Actualización de tu ticket</h1>
+            </div>
+            <div class="content">
+                <p>Hola <span th:text="${userName}">Usuario</span>,</p>
+                <p>Tu ticket de soporte ha sido actualizado:</p>
+
+                <div class="ticket-info">
+                    <p><strong>Número de ticket:</strong> <span th:text="${ticketNumber}">#12345</span></p>
+                    <p><strong>Asunto:</strong> <span th:text="${ticketSubject}">Problema con el pedido</span></p>
+                    <p>
+                        <strong>Estado actual:</strong> 
+                        <span class="status-badge" th:text="${ticketStatus}">En progreso</span>
+                    </p>
+                    <p><strong>Última actualización:</strong> <span th:text="${updateDate}">13/03/2026 16:45</span></p>
+                </div>
+
+                <div class="update-box">
+                    <p class="author">
+                        <strong th:text="${respondentName}">Equipo de Soporte</strong> ha respondido:
+                    </p>
+                    <div class="response-message">
+                        <p th:text="${responseMessage}">
+                            Gracias por tu paciencia. Hemos revisado tu caso y estamos trabajando en una solución. 
+                            Te mantendremos informado sobre cualquier novedad.
+                        </p>
+                    </div>
+                </div>
+
+                <p th:if="${nextSteps != null}" style="margin-top: 20px;">
+                    <strong>Próximos pasos:</strong><br/>
+                    <span th:text="${nextSteps}">Te contactaremos en las próximas 24 horas.</span>
+                </p>
+
+                <a th:href="${ticketLink}" class="btn-view-ticket">Ver ticket completo</a>
+
+                <p style="margin-top: 20px; font-size: 13px; color: #666;">
+                    Puedes responder a este ticket directamente desde tu panel de usuario.
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2026 Tu Empresa. Todos los derechos reservados.</p>
+            <p>
+                <a href="#">Términos</a> | 
+                <a href="#">Privacidad</a> | 
+                <a href="#">Ayuda</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/emails/support/ticket-user.html
+++ b/src/main/resources/templates/emails/support/ticket-user.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Arial", sans-serif;
+            background-color: #f3f3f3;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .email-wrapper {
+            width: 100%;
+            padding: 20px 0;
+            background-color: #f3f3f3;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #232f3e;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header img {
+            max-width: 120px;
+            margin-bottom: 10px;
+        }
+        .content {
+            padding: 30px 25px;
+        }
+        .content h2 {
+            color: #232f3e;
+            margin-top: 0;
+        }
+        .content p {
+            line-height: 1.6;
+            font-size: 15px;
+        }
+        .ticket-info {
+            background-color: #f8f9fa;
+            border-left: 4px solid #007bff;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .ticket-info p {
+            margin: 5px 0;
+        }
+        .ticket-info strong {
+            color: #232f3e;
+        }
+        .message-box {
+            background-color: #fff;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .btn-view-ticket {
+            display: inline-block;
+            background-color: #f90;
+            color: #111 !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 14px 28px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777777;
+            text-align: center;
+            padding: 15px 20px;
+            background-color: #f3f3f3;
+        }
+        .footer a {
+            color: #232f3e;
+            text-decoration: none;
+            margin: 0 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-wrapper">
+        <div class="email-container">
+            <div class="header">
+                <img th:if="${hasLogo}" src="cid:logoImage" alt="Tu Empresa" />
+                <h1>Ticket de soporte creado</h1>
+            </div>
+            <div class="content">
+                <p>Hola <span th:text="${userName}">Usuario</span>,</p>
+                <p>Hemos recibido tu solicitud de soporte. Aquí tienes los detalles de tu ticket:</p>
+
+                <div class="ticket-info">
+                    <p><strong>Número de ticket:</strong> <span th:text="${ticketNumber}">#12345</span></p>
+                    <p><strong>Asunto:</strong> <span th:text="${ticketSubject}">Problema con el pedido</span></p>
+                    <p><strong>Categoría:</strong> <span th:text="${ticketCategory}">Pedidos</span></p>
+                    <p><strong>Prioridad:</strong> <span th:text="${ticketPriority}">Media</span></p>
+                    <p><strong>Fecha de creación:</strong> <span th:text="${createdDate}">13/03/2026 14:30</span></p>
+                </div>
+
+                <p><strong>Tu mensaje:</strong></p>
+                <div class="message-box">
+                    <p th:text="${userMessage}">
+                        Este es el mensaje inicial del usuario describiendo su problema o consulta.
+                    </p>
+                </div>
+
+                <p>Nuestro equipo de soporte revisará tu solicitud y te responderá lo antes posible.</p>
+                <p>Tiempo estimado de respuesta: <strong th:text="${estimatedResponseTime}">24-48 horas</strong></p>
+
+                <a th:href="${ticketLink}" class="btn-view-ticket">Ver ticket</a>
+
+                <p style="margin-top: 20px; font-size: 13px; color: #666;">
+                    Recibirás una notificación por email cada vez que haya una actualización en tu ticket.
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2026 Tu Empresa. Todos los derechos reservados.</p>
+            <p>
+                <a href="#">Términos</a> | 
+                <a href="#">Privacidad</a> | 
+                <a href="#">Ayuda</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/emails/user/account-banned.html
+++ b/src/main/resources/templates/emails/user/account-banned.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Arial", sans-serif;
+            background-color: #f3f3f3;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .email-wrapper {
+            width: 100%;
+            padding: 20px 0;
+            background-color: #f3f3f3;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background-color: #c41e3a;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header img {
+            max-width: 120px;
+            margin-bottom: 10px;
+        }
+        .content {
+            padding: 30px 25px;
+        }
+        .content h2 {
+            color: #c41e3a;
+            margin-top: 0;
+        }
+        .content p {
+            line-height: 1.6;
+            font-size: 15px;
+        }
+        .warning-box {
+            background-color: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .warning-box strong {
+            color: #856404;
+        }
+        .btn-support {
+            display: inline-block;
+            background-color: #232f3e;
+            color: white !important;
+            font-weight: bold;
+            text-decoration: none;
+            padding: 14px 28px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777777;
+            text-align: center;
+            padding: 15px 20px;
+            background-color: #f3f3f3;
+        }
+        .footer a {
+            color: #232f3e;
+            text-decoration: none;
+            margin: 0 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-wrapper">
+        <div class="email-container">
+            <div class="header">
+                <img th:if="${hasLogo}" src="cid:logoImage" alt="Tu Empresa" />
+                <h1>Cuenta baneada</h1>
+            </div>
+            <div class="content">
+                <p>Hola <span th:text="${userName}">Usuario</span>,</p>
+                
+                <div class="warning-box">
+                    <strong>Tu cuenta ha sido permanentemente baneada.</strong>
+                </div>
+
+                <p th:text="${banReason}">
+                    Tu cuenta ha sido baneada debido al incumplimiento de nuestras políticas de uso y términos de servicio.
+                </p>
+
+                <p><strong>Fecha del baneo:</strong> <span th:text="${banDate}">13/03/2026</span></p>
+
+                <p>
+                    Si crees que este baneo ha sido un error o deseas apelar esta decisión, 
+                    puedes contactar con nuestro equipo de soporte haciendo clic en el botón de abajo:
+                </p>
+
+                <a th:href="${supportLink}" class="btn-support">Contactar con soporte</a>
+
+                <p style="margin-top: 30px; font-size: 13px; color: #666;">
+                    <strong>Importante:</strong> Durante el periodo de baneo, no podrás acceder a tu cuenta 
+                    ni realizar ninguna acción en la plataforma. Todos los pedidos pendientes han sido cancelados.
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2026 Tu Empresa. Todos los derechos reservados.</p>
+            <p>
+                <a href="#">Términos</a> | 
+                <a href="#">Privacidad</a> | 
+                <a href="#">Ayuda</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Descripción

Primera parte del Issue #116: Plantillas HTML Thymeleaf para los nuevos tipos de emails del sistema de notificaciones.

## Plantillas incluidas

### Soporte (4 plantillas)
- **ticket-user.html** (136 líneas): Confirmación de creación de ticket para el usuario
- **ticket-admin.html** (167 líneas): Alerta de nuevo ticket para administradores  
- **ticket-update.html** (168 líneas): Notificación de actualización de ticket
- **ticket-close.html** (175 líneas): Confirmación de cierre de ticket

### Usuario (1 plantilla)
- **account-banned.html** (123 líneas): Notificación de suspensión de cuenta

## Características técnicas

- Diseño responsive compatible con clientes de email
- Inline CSS para máxima compatibilidad
- Soporte para logo de empresa via CID inline
- Variables Thymeleaf para contenido dinámico
- Estilos consistentes con plantillas existentes

## Tamaño
- Total: 769 líneas en 5 archivos HTML
- Sin dependencias de código Java (siguiente PR)

## Issue relacionado
Refs #116 (Parte 1 de 3)