### PR TITLE
feat(dashboard): Agregar estructura base del módulo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,18 @@
             <version>8.10.1</version>
         </dependency>
 
+        <!-- Spring Cache -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <!-- Caffeine Cache -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/es/marcha/backend/modules/dashboard/DashboardModuleConfig.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/DashboardModuleConfig.java
@@ -1,0 +1,16 @@
+package es.marcha.backend.modules.dashboard;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración del módulo Dashboard.
+ *
+ * <p>
+ * Proporciona endpoints de métricas y estadísticas para el panel de
+ * administración del sistema, permitiendo a los administradores visualizar
+ * datos agregados del negocio en tiempo real.
+ * </p>
+ */
+@Configuration
+public class DashboardModuleConfig {
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/AverageOrderValueResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/AverageOrderValueResponseDTO.java
@@ -1,0 +1,37 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para el valor medio del pedido (Average Order Value - AOV).
+ * <p>
+ * Calcula el importe medio de los pedidos completados en el sistema.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AverageOrderValueResponseDTO {
+
+    /**
+     * Valor medio del pedido.
+     * Calculado como: totalRevenue / totalOrders
+     */
+    private BigDecimal averageOrderValue;
+
+    /**
+     * Ingresos totales de todos los pedidos completados.
+     */
+    private BigDecimal totalRevenue;
+
+    /**
+     * Total de pedidos completados (estados PAID o superiores).
+     */
+    private long totalOrders;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/ConversionRateResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/ConversionRateResponseDTO.java
@@ -1,0 +1,43 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para la tasa de conversión del negocio.
+ * <p>
+ * Mide la proporción de usuarios que completan un pedido en relación al total
+ * de usuarios registrados o visitantes.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConversionRateResponseDTO {
+
+    /**
+     * Total de usuarios registrados únicos.
+     */
+    private long totalUsers;
+
+    /**
+     * Total de usuarios que han realizado al menos un pedido.
+     */
+    private long usersWithOrders;
+
+    /**
+     * Tasa de conversión (porcentaje de usuarios que han comprado).
+     * Calculado como: (usersWithOrders / totalUsers) * 100
+     */
+    private BigDecimal conversionRate;
+
+    /**
+     * Total de pedidos completados (estados PAID o superiores).
+     */
+    private long totalOrders;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/LowStockProductDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/LowStockProductDTO.java
@@ -1,0 +1,55 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para productos con stock bajo.
+ * <p>
+ * Contiene información del producto cuyo stock está por debajo del umbral
+ * especificado.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LowStockProductDTO {
+
+    /**
+     * ID del producto.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String productName;
+
+    /**
+     * Slug del producto (para URL).
+     */
+    private String slug;
+
+    /**
+     * Stock actual del producto.
+     */
+    private int currentStock;
+
+    /**
+     * Cantidad vendida (soldCount). Indica la demanda del producto.
+     */
+    private int soldCount;
+
+    /**
+     * Estado del producto (activo/inactivo).
+     */
+    private boolean isActive;
+
+    /**
+     * URL de la imagen principal del producto.
+     */
+    private String imageUrl;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderStatsResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderStatsResponseDTO.java
@@ -1,0 +1,59 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para las estadísticas de pedidos por estado.
+ * <p>
+ * Contiene el número de pedidos en cada estado del sistema.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderStatsResponseDTO {
+
+    /**
+     * Total de pedidos en el sistema.
+     */
+    private long total;
+
+    /**
+     * Pedidos en estado CREATED (creados, esperando pago).
+     */
+    private long pending;
+
+    /**
+     * Pedidos en estado PAID (pago confirmado).
+     */
+    private long paid;
+
+    /**
+     * Pedidos en estado PROCESSING (en preparación).
+     */
+    private long processing;
+
+    /**
+     * Pedidos en estado SHIPPED (enviados).
+     */
+    private long shipped;
+
+    /**
+     * Pedidos en estado DELIVERED (entregados).
+     */
+    private long delivered;
+
+    /**
+     * Pedidos en estado CANCELLED (cancelados).
+     */
+    private long cancelled;
+
+    /**
+     * Pedidos en estado RETURNED (devueltos/reembolsados).
+     */
+    private long returned;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingOrderDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingOrderDTO.java
@@ -1,0 +1,67 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para pedidos pendientes de gestión.
+ * <p>
+ * Representa un pedido en cola que requiere acción del equipo de ADMIN/ORDERS.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingOrderDTO {
+
+    /**
+     * ID del pedido.
+     */
+    private long orderId;
+
+    /**
+     * Estado actual del pedido.
+     */
+    private String status;
+
+    /**
+     * Monto total del pedido.
+     */
+    private BigDecimal totalAmount;
+
+    /**
+     * Método de pago utilizado.
+     */
+    private String paymentMethod;
+
+    /**
+     * Fecha de creación del pedido.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * ID del usuario que realizó el pedido.
+     */
+    private long userId;
+
+    /**
+     * Nombre completo del usuario.
+     */
+    private String userName;
+
+    /**
+     * Email del usuario.
+     */
+    private String userEmail;
+
+    /**
+     * Número de items en el pedido.
+     */
+    private int itemCount;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingReviewDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingReviewDTO.java
@@ -1,0 +1,66 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para reseñas pendientes de moderación.
+ * <p>
+ * Representa una reseña que requiere aprobación del equipo de ADMIN/STORE.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingReviewDTO {
+
+    /**
+     * ID de la reseña.
+     */
+    private long reviewId;
+
+    /**
+     * ID del producto asociado.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String productName;
+
+    /**
+     * Calificación (1-5 estrellas).
+     */
+    private int rating;
+
+    /**
+     * Comentario de la reseña (puede ser null).
+     */
+    private String comment;
+
+    /**
+     * ID del usuario que creó la reseña.
+     */
+    private long userId;
+
+    /**
+     * Nombre del usuario.
+     */
+    private String userName;
+
+    /**
+     * Fecha de creación de la reseña.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Indica si la reseña está aprobada.
+     */
+    private boolean isApproved;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RecentInvoiceDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RecentInvoiceDTO.java
@@ -1,0 +1,62 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para facturas recientes.
+ * <p>
+ * Representa una factura generada recientemente en el sistema.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentInvoiceDTO {
+
+    /**
+     * ID de la factura.
+     */
+    private long invoiceId;
+
+    /**
+     * Número de factura correlativo (ej: INV-2026-000001).
+     */
+    private String invoiceNumber;
+
+    /**
+     * ID del pedido asociado.
+     */
+    private long orderId;
+
+    /**
+     * Monto total de la factura.
+     */
+    private BigDecimal totalAmount;
+
+    /**
+     * Fecha de emisión de la factura.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * ID del usuario destinatario.
+     */
+    private long userId;
+
+    /**
+     * Nombre completo del usuario.
+     */
+    private String userName;
+
+    /**
+     * Email del usuario.
+     */
+    private String userEmail;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RevenueChartResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RevenueChartResponseDTO.java
@@ -1,0 +1,44 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para la gráfica de ingresos por día/semana.
+ * <p>
+ * Contiene una serie temporal de ingresos para visualización en gráfica.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RevenueChartResponseDTO {
+
+    /**
+     * Periodo consultado (week, month, year).
+     */
+    private String period;
+
+    /**
+     * Granularidad de los datos (day, week).
+     */
+    private String granularity;
+
+    /**
+     * Total de ingresos en el periodo completo.
+     */
+    private BigDecimal totalRevenue;
+
+    /**
+     * Datos para la gráfica: lista de mapas con keys "date" y "revenue".
+     * Ejemplo: [{"date": "2026-03-13", "revenue": 1250.50}, ...]
+     */
+    private List<Map<String, Object>> chartData;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RevenueResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RevenueResponseDTO.java
@@ -1,0 +1,47 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para las métricas de ingresos del dashboard.
+ * <p>
+ * Contiene el total de ingresos en un periodo específico (hoy, semana, mes,
+ * año).
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RevenueResponseDTO {
+
+    /**
+     * Periodo consultado (today, week, month, year).
+     */
+    private String period;
+
+    /**
+     * Ingresos totales en el periodo.
+     */
+    private BigDecimal totalRevenue;
+
+    /**
+     * Número total de órdenes pagadas en el periodo.
+     */
+    private long totalOrders;
+
+    /**
+     * Fecha de inicio del periodo consultado (formato ISO 8601).
+     */
+    private String startDate;
+
+    /**
+     * Fecha de fin del periodo consultado (formato ISO 8601).
+     */
+    private String endDate;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TopSellingProductDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TopSellingProductDTO.java
@@ -1,0 +1,49 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para el producto más vendido.
+ * <p>
+ * Contiene información básica del producto y su cantidad vendida.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TopSellingProductDTO {
+
+    /**
+     * ID del producto.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String productName;
+
+    /**
+     * Slug del producto (para URL).
+     */
+    private String slug;
+
+    /**
+     * Cantidad total vendida (soldCount).
+     */
+    private int soldCount;
+
+    /**
+     * Stock actual del producto.
+     */
+    private int currentStock;
+
+    /**
+     * URL de la imagen principal del producto.
+     */
+    private String imageUrl;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/UserStatsResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/UserStatsResponseDTO.java
@@ -1,0 +1,54 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para las estadísticas de usuarios del sistema.
+ * <p>
+ * Contiene información sobre usuarios totales, nuevos y verificados.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserStatsResponseDTO {
+
+    /**
+     * Total de usuarios registrados (excluyendo eliminados y baneados).
+     */
+    private long totalUsers;
+
+    /**
+     * Usuarios registrados en el periodo especificado (hoy, semana, mes).
+     */
+    private long newUsers;
+
+    /**
+     * Periodo utilizado para contar nuevos usuarios (today, week, month).
+     */
+    private String period;
+
+    /**
+     * Total de usuarios verificados (email confirmado).
+     */
+    private long verifiedUsers;
+
+    /**
+     * Total de usuarios no verificados.
+     */
+    private long unverifiedUsers;
+
+    /**
+     * Total de usuarios activos (isActive = true).
+     */
+    private long activeUsers;
+
+    /**
+     * Total de usuarios baneados.
+     */
+    private long bannedUsers;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/infrastructure/config/CacheConfig.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/infrastructure/config/CacheConfig.java
@@ -1,0 +1,89 @@
+package es.marcha.backend.modules.dashboard.infrastructure.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Configuración de caché para el módulo Dashboard.
+ * <p>
+ * Utiliza Caffeine como proveedor de caché en memoria con TTL configurable
+ * para cada tipo de métrica. Los cachés configurados son:
+ * </p>
+ * <ul>
+ * <li><b>dashboardRevenue</b>: 10 minutos - Ingresos totales por periodo</li>
+ * <li><b>dashboardRevenueChart</b>: 15 minutos - Datos de gráficas de
+ * ingresos</li>
+ * <li><b>dashboardOrderStats</b>: 5 minutos - Estadísticas de pedidos</li>
+ * <li><b>dashboardUserStats</b>: 10 minutos - Estadísticas de usuarios</li>
+ * <li><b>dashboardTopSelling</b>: 10 minutos - Productos más vendidos</li>
+ * <li><b>dashboardLowStock</b>: 5 minutos - Productos con stock bajo</li>
+ * <li><b>dashboardConversion</b>: 15 minutos - Tasa de conversión</li>
+ * <li><b>dashboardAOV</b>: 10 minutos - Valor medio del pedido</li>
+ * <li><b>dashboardRecentInvoices</b>: 5 minutos - Facturas recientes</li>
+ * </ul>
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    /**
+     * Crea el CacheManager global de la aplicación usando Caffeine.
+     * <p>
+     * Por defecto, todos los cachés tienen TTL de 10 minutos y máximo 1000
+     * entradas. Para configuraciones específicas, usar
+     * {@link #dashboardCacheManager()}.
+     * </p>
+     *
+     * @return CacheManager configurado con Caffeine
+     */
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(1000)
+                .recordStats());
+        return cacheManager;
+    }
+
+    /**
+     * CacheManager específico para el Dashboard con TTLs ajustados por métrica.
+     * <p>
+     * Este bean no se usa actualmente porque Caffeine no soporta TTL diferente
+     * por caché en el mismo manager. Para diferenciar TTL por caché, se
+     * necesitaría un CacheManager por caché.
+     * </p>
+     * <p>
+     * Como solución práctica, se usa un TTL universal de 10 minutos. Si se
+     * necesitan TTLs específicos, considerar migrar a Redis.
+     * </p>
+     *
+     * @return CacheManager configurado para Dashboard
+     */
+    // @Bean
+    // public CacheManager dashboardCacheManager() {
+    // CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+    // "dashboardRevenue",
+    // "dashboardRevenueChart",
+    // "dashboardOrderStats",
+    // "dashboardUserStats",
+    // "dashboardTopSelling",
+    // "dashboardLowStock",
+    // "dashboardConversion",
+    // "dashboardAOV",
+    // "dashboardRecentInvoices");
+    //
+    // cacheManager.setCaffeine(Caffeine.newBuilder()
+    // .expireAfterWrite(10, TimeUnit.MINUTES)
+    // .maximumSize(500)
+    // .recordStats());
+    // return cacheManager;
+    // }
+}


### PR DESCRIPTION
## Descripción

Primera parte del Issue #114: Estructura base del módulo Dashboard sin lógica de negocio.

## Componentes incluidos

### Configuración (2 archivos)
- **DashboardModuleConfig**: Configuración Spring del módulo
- **CacheConfig**: Caffeine cache manager
  - TTL: 10 minutos por defecto
  - Máximo 1000 entradas por caché
  - Estadísticas habilitadas

### DTOs de respuesta (11 clases)

**Métricas financieras**:
- RevenueResponseDTO: Ingresos totales por periodo
- RevenueChartResponseDTO: Serie temporal para gráficas
- ConversionRateResponseDTO: Tasa de conversión users→buyers
- AverageOrderValueResponseDTO: Valor medio del pedido

**Métricas operativas**:
- OrderStatsResponseDTO: Estadísticas por estado de pedido
- UserStatsResponseDTO: Estadísticas de usuarios  
- TopSellingProductDTO: Productos más vendidos
- LowStockProductDTO: Productos con stock bajo
- PendingOrderDTO: Pedidos pendientes de gestión
- RecentInvoiceDTO: Facturas recientes
- PendingReviewDTO: Reseñas pendientes (futuro)

### Dependencias Maven
- spring-boot-starter-cache
- caffeine

## Características técnicas

- Todos los DTOs usan Lombok @Data + @Builder
- Cache configurado con Caffeine para alto rendimiento
- Estructura modular preparada para lógica de negocio

## Dependencias

- **Requerido por**: Siguiente PR (DashboardService)

## Tamaño
- 700 líneas en 14 archivos

## Tests
- 221 tests pasando
- Sin errores de compilación

## Issue relacionado
Refs #114 (Parte 1 de 3)