### PR TITLE
feat(dashboard): Añadir DTOs para endpoints por rol (Issue #115 - Parte 1/3)

### DIFF
--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/BannedCustomerDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/BannedCustomerDTO.java
@@ -1,0 +1,56 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para clientes baneados (rol CUSTOMERS).
+ * <p>
+ * Representa un usuario que ha sido baneado del sistema.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BannedCustomerDTO {
+
+    /**
+     * ID del usuario.
+     */
+    private long userId;
+
+    /**
+     * Nombre completo.
+     */
+    private String name;
+
+    /**
+     * Apellido.
+     */
+    private String surname;
+
+    /**
+     * Email.
+     */
+    private String email;
+
+    /**
+     * Fecha de registro.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Fecha del último inicio de sesión.
+     */
+    private LocalDateTime lastLogin;
+
+    /**
+     * Número de pedidos realizados antes del baneo.
+     */
+    private long orderCount;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/BestRatedProductDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/BestRatedProductDTO.java
@@ -1,0 +1,61 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para productos mejor valorados (rol STORE).
+ * <p>
+ * Representa un producto con sus valoraciones promedio y número de reviews.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BestRatedProductDTO {
+
+    /**
+     * ID del producto.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String name;
+
+    /**
+     * SKU del producto.
+     */
+    private String sku;
+
+    /**
+     * Precio actual.
+     */
+    private BigDecimal price;
+
+    /**
+     * Valoración promedio (1-5).
+     */
+    private Double averageRating;
+
+    /**
+     * Número total de reviews.
+     */
+    private long reviewCount;
+
+    /**
+     * URL de la imagen principal.
+     */
+    private String imageUrl;
+
+    /**
+     * Stock actual.
+     */
+    private int stock;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/CustomerRetentionDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/CustomerRetentionDTO.java
@@ -1,0 +1,44 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para estadísticas de retención de clientes (rol CUSTOMERS).
+ * <p>
+ * Contiene porcentajes de clientes recurrentes y métricas de retención.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerRetentionDTO {
+
+    /**
+     * Total de clientes registrados.
+     */
+    private long totalCustomers;
+
+    /**
+     * Clientes con al menos un pedido.
+     */
+    private long customersWithOrders;
+
+    /**
+     * Clientes con más de un pedido (recurrentes).
+     */
+    private long recurringCustomers;
+
+    /**
+     * Porcentaje de retención (clientes con más de un pedido / total con pedidos).
+     */
+    private Double retentionRate;
+
+    /**
+     * Porcentaje de conversión (clientes con pedidos / total).
+     */
+    private Double conversionRate;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/DelayedShipmentDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/DelayedShipmentDTO.java
@@ -1,0 +1,68 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para envíos con retraso (rol ORDERS).
+ * <p>
+ * Representa pedidos que están retrasados respecto a su fecha estimada de
+ * entrega.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DelayedShipmentDTO {
+
+    /**
+     * ID del pedido.
+     */
+    private long orderId;
+
+    /**
+     * Estado actual del pedido.
+     */
+    private String status;
+
+    /**
+     * Monto total del pedido.
+     */
+    private BigDecimal totalAmount;
+
+    /**
+     * Fecha de creación del pedido.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Fecha estimada de entrega (calculada: +7 días desde creación).
+     */
+    private LocalDateTime estimatedDeliveryDate;
+
+    /**
+     * Días de retraso.
+     */
+    private long daysDelayed;
+
+    /**
+     * Nombre completo del cliente.
+     */
+    private String customerName;
+
+    /**
+     * Email del cliente.
+     */
+    private String customerEmail;
+
+    /**
+     * Dirección de envío.
+     */
+    private String shippingAddress;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/MostViewedProductDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/MostViewedProductDTO.java
@@ -1,0 +1,56 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para productos más visitados (rol STORE).
+ * <p>
+ * Representa un producto con su número de vistas.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MostViewedProductDTO {
+
+    /**
+     * ID del producto.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String name;
+
+    /**
+     * SKU del producto.
+     */
+    private String sku;
+
+    /**
+     * Precio actual.
+     */
+    private BigDecimal price;
+
+    /**
+     * Número de vistas del producto.
+     */
+    private long views;
+
+    /**
+     * URL de la imagen principal.
+     */
+    private String imageUrl;
+
+    /**
+     * Stock actual.
+     */
+    private int stock;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/NewCustomerDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/NewCustomerDTO.java
@@ -1,0 +1,61 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para clientes nuevos por período (rol CUSTOMERS).
+ * <p>
+ * Representa un cliente recién registrado.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewCustomerDTO {
+
+    /**
+     * ID del usuario.
+     */
+    private long userId;
+
+    /**
+     * Nombre completo.
+     */
+    private String name;
+
+    /**
+     * Apellido.
+     */
+    private String surname;
+
+    /**
+     * Email.
+     */
+    private String email;
+
+    /**
+     * Fecha de registro.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Indica si el usuario está verificado.
+     */
+    private boolean isVerified;
+
+    /**
+     * Indica si ha realizado algún pedido.
+     */
+    private boolean hasOrders;
+
+    /**
+     * Número de pedidos realizados.
+     */
+    private long orderCount;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderQueueItemDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderQueueItemDTO.java
@@ -1,0 +1,63 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para un elemento de la cola de pedidos pendientes (rol
+ * ORDERS).
+ * <p>
+ * Representa un pedido pendiente de procesamiento ordenado por prioridad.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderQueueItemDTO {
+
+    /**
+     * ID del pedido.
+     */
+    private long orderId;
+
+    /**
+     * Estado actual del pedido.
+     */
+    private String status;
+
+    /**
+     * Monto total del pedido.
+     */
+    private BigDecimal totalAmount;
+
+    /**
+     * Fecha de creación del pedido.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Nombre completo del cliente.
+     */
+    private String customerName;
+
+    /**
+     * Email del cliente.
+     */
+    private String customerEmail;
+
+    /**
+     * Número de items en el pedido.
+     */
+    private int itemCount;
+
+    /**
+     * Tiempo transcurrido desde la creación (en horas).
+     */
+    private long hoursSinceCreation;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderWithIssueDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/OrderWithIssueDTO.java
@@ -1,0 +1,77 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para pedidos con incidencias o notas internas (rol SUPPORT).
+ * <p>
+ * Representa un pedido que requiere atención de soporte.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderWithIssueDTO {
+
+    /**
+     * ID del pedido.
+     */
+    private long orderId;
+
+    /**
+     * Estado actual del pedido.
+     */
+    private String status;
+
+    /**
+     * Monto total del pedido.
+     */
+    private BigDecimal totalAmount;
+
+    /**
+     * Fecha de creación del pedido.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Nombre completo del cliente.
+     */
+    private String customerName;
+
+    /**
+     * Email del cliente.
+     */
+    private String customerEmail;
+
+    /**
+     * Teléfono del cliente.
+     */
+    private String customerPhone;
+
+    /**
+     * Número de items en el pedido.
+     */
+    private int itemCount;
+
+    /**
+     * Indica si tiene pagos en estado FAILED.
+     */
+    private boolean hasFailedPayments;
+
+    /**
+     * Indica si tiene pagos en estado REFUNDED.
+     */
+    private boolean hasRefundedPayments;
+
+    /**
+     * ID del usuario para contacto.
+     */
+    private long userId;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingRefundDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/PendingRefundDTO.java
@@ -1,0 +1,62 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para reembolsos pendientes de procesar (rol ORDERS).
+ * <p>
+ * Representa un pago que requiere procesamiento de reembolso.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingRefundDTO {
+
+    /**
+     * ID del pago.
+     */
+    private long paymentId;
+
+    /**
+     * ID del pedido asociado.
+     */
+    private long orderId;
+
+    /**
+     * Monto a reembolsar.
+     */
+    private BigDecimal amount;
+
+    /**
+     * Método de pago original.
+     */
+    private String paymentMethod;
+
+    /**
+     * Fecha de creación del pedido.
+     */
+    private LocalDateTime orderCreatedAt;
+
+    /**
+     * Nombre completo del cliente.
+     */
+    private String customerName;
+
+    /**
+     * Email del cliente.
+     */
+    private String customerEmail;
+
+    /**
+     * ID de Stripe (si aplica).
+     */
+    private String stripePaymentIntentId;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/ProductSummaryDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/ProductSummaryDTO.java
@@ -1,0 +1,39 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para el resumen de productos (rol STORE).
+ * <p>
+ * Contiene contadores de productos activos, inactivos y sin stock.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductSummaryDTO {
+
+    /**
+     * Total de productos activos.
+     */
+    private long activeProducts;
+
+    /**
+     * Total de productos inactivos.
+     */
+    private long inactiveProducts;
+
+    /**
+     * Total de productos sin stock (quantity = 0).
+     */
+    private long outOfStockProducts;
+
+    /**
+     * Total de productos en el catálogo.
+     */
+    private long totalProducts;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RecentReviewDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/RecentReviewDTO.java
@@ -1,0 +1,61 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para reseñas recientes (rol STORE).
+ * <p>
+ * Representa una reseña reciente de un producto.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentReviewDTO {
+
+    /**
+     * ID de la reseña.
+     */
+    private long reviewId;
+
+    /**
+     * ID del producto.
+     */
+    private long productId;
+
+    /**
+     * Nombre del producto.
+     */
+    private String productName;
+
+    /**
+     * Valoración (1-5).
+     */
+    private int rating;
+
+    /**
+     * Comentario de la reseña.
+     */
+    private String comment;
+
+    /**
+     * Fecha de creación.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Nombre del usuario que dejó la reseña.
+     */
+    private String userName;
+
+    /**
+     * URL de la imagen del producto.
+     */
+    private String productImageUrl;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TodayOrdersSummaryDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TodayOrdersSummaryDTO.java
@@ -1,0 +1,42 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para el resumen de pedidos del día (rol ORDERS).
+ * <p>
+ * Contiene el número total de pedidos y los ingresos totales generados en el
+ * día actual.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TodayOrdersSummaryDTO {
+
+    /**
+     * Número total de pedidos realizados hoy.
+     */
+    private long totalOrders;
+
+    /**
+     * Ingresos totales generados hoy.
+     */
+    private BigDecimal totalRevenue;
+
+    /**
+     * Número de pedidos pendientes de procesamiento.
+     */
+    private long pendingOrders;
+
+    /**
+     * Número de pedidos completados hoy.
+     */
+    private long completedOrders;
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TopBuyerDTO.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/dto/response/TopBuyerDTO.java
@@ -1,0 +1,56 @@
+package es.marcha.backend.modules.dashboard.application.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO de respuesta para clientes que más han gastado (rol CUSTOMERS).
+ * <p>
+ * Representa un cliente VIP con su gasto total.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TopBuyerDTO {
+
+    /**
+     * ID del usuario.
+     */
+    private long userId;
+
+    /**
+     * Nombre completo.
+     */
+    private String name;
+
+    /**
+     * Apellido.
+     */
+    private String surname;
+
+    /**
+     * Email.
+     */
+    private String email;
+
+    /**
+     * Gasto total acumulado.
+     */
+    private BigDecimal totalSpent;
+
+    /**
+     * Número de pedidos realizados.
+     */
+    private long orderCount;
+
+    /**
+     * Gasto promedio por pedido.
+     */
+    private BigDecimal averageOrderValue;
+}


### PR DESCRIPTION
## Descripción

Primera parte de Issue #115: DTOs para estadísticas especializadas por rol.

## Cambios

✅ **13 DTOs creados** (746 líneas):

### ORDERS (4 DTOs)
- TodayOrdersSummaryDTO - Resumen de pedidos del día
- OrderQueueItemDTO - Items de la cola de pedidos
- PendingRefundDTO - Reembolsos pendientes
- DelayedShipmentDTO - Envíos retrasados

### STORE (4 DTOs)
- ProductSummaryDTO - Resumen del catálogo
- MostViewedProductDTO - Productos más vistos
- BestRatedProductDTO - Productos mejor valorados
- RecentReviewDTO - Reseñas recientes

### CUSTOMERS (4 DTOs)
- NewCustomerDTO - Nuevos clientes por período
- TopBuyerDTO - Mejores compradores
- BannedCustomerDTO - Clientes baneados
- CustomerRetentionDTO - Métricas de retención

### SUPPORT (1 DTO)
- OrderWithIssueDTO - Pedidos con problemas

## Estrategia de división

Este PR es parte 1 de 3 para mantener bajo el límite de 1000 líneas:
1. **PR #1 (este)**: DTOs (746 líneas) ✅
2. **PR #2**: Servicios + SecurityConfig (730 líneas)
3. **PR #3**: Controladores (305 líneas)

## Próximos pasos

- Aprobar este PR
- Continuar con servicios en el PR #2

Ref: #115