### PR TITLE
feat(dashboard): Añadir servicios especializados por rol (Issue #115 - Parte 2/3)

### DIFF
--- a/src/main/java/es/marcha/backend/core/auth/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/es/marcha/backend/core/auth/infrastructure/config/SecurityConfig.java
@@ -237,7 +237,20 @@ public class SecurityConfig {
                                                 .requestMatchers("/coupons/**")
                                                 .hasAnyRole("SUPER_ADMIN", "ADMIN")
 
-                                                // === Dashboard: métricas y estadísticas solo SUPER_ADMIN y ADMIN ===
+                                                // === Dashboard: métricas por rol (Issue #115) ===
+                                                // Dashboard de pedidos — rol ORDERS
+                                                .requestMatchers("/dashboard/orders/**")
+                                                .hasRole("ORDERS")
+                                                // Dashboard de catálogo — rol STORE
+                                                .requestMatchers("/dashboard/store/**")
+                                                .hasRole("STORE")
+                                                // Dashboard de clientes — rol CUSTOMERS_INVOICES
+                                                .requestMatchers("/dashboard/customers/**")
+                                                .hasRole("CUSTOMERS_INVOICES")
+                                                // Dashboard de soporte — rol SUPPORT
+                                                .requestMatchers("/dashboard/support/**")
+                                                .hasRole("SUPPORT")
+                                                // Dashboard general — SUPER_ADMIN y ADMIN
                                                 .requestMatchers("/dashboard/**")
                                                 .hasAnyRole("SUPER_ADMIN", "ADMIN")
 

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/service/CustomersDashboardService.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/service/CustomersDashboardService.java
@@ -1,0 +1,205 @@
+package es.marcha.backend.modules.dashboard.application.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.marcha.backend.core.user.domain.model.User;
+import es.marcha.backend.core.user.infrastructure.persistence.UserRepository;
+import es.marcha.backend.modules.dashboard.application.dto.response.BannedCustomerDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.CustomerRetentionDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.NewCustomerDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.TopBuyerDTO;
+import es.marcha.backend.modules.order.domain.model.Order;
+import es.marcha.backend.modules.order.infrastructure.persistence.OrderRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Servicio especializado para métricas y operaciones del dashboard de clientes.
+ * <p>
+ * Proporciona estadísticas de usuarios, nuevos clientes, top compradores y
+ * retención.
+ * Todos los métodos están cacheados y son de solo lectura.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomersDashboardService {
+
+    private final UserRepository userRepository;
+    private final OrderRepository orderRepository;
+
+    /**
+     * Obtiene la lista de nuevos clientes registrados en un período específico.
+     * <p>
+     * Períodos soportados: "week", "month", "quarter", "year".
+     * Por defecto usa "week" si el período no es válido.
+     * </p>
+     *
+     * @param period Período a consultar (week/month/quarter/year)
+     * @param limit  Número máximo de clientes a retornar
+     * @return Lista de NewCustomerDTO ordenada por fecha de registro (descendente)
+     */
+    @Cacheable(value = "newCustomers")
+    public List<NewCustomerDTO> getNewCustomers(String period, int limit) {
+        LocalDateTime since = switch (period.toLowerCase()) {
+            case "week" -> LocalDateTime.now().minusWeeks(1);
+            case "month" -> LocalDateTime.now().minusMonths(1);
+            case "quarter" -> LocalDateTime.now().minusMonths(3);
+            case "year" -> LocalDateTime.now().minusYears(1);
+            default -> LocalDateTime.now().minusWeeks(1);
+        };
+
+        return userRepository.findAll().stream()
+                .filter(user -> !user.isDeleted() && !user.isBanned())
+                .filter(user -> user.getCreatedAt() != null && user.getCreatedAt().isAfter(since))
+                .sorted(Comparator.comparing(User::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .map(user -> {
+                    // Contar pedidos del usuario
+                    List<Order> userOrders = orderRepository.findAllByUserId(user.getId());
+                    long orderCount = userOrders.size();
+                    boolean hasOrders = orderCount > 0;
+
+                    return NewCustomerDTO.builder()
+                            .userId(user.getId())
+                            .name(user.getName())
+                            .surname(user.getSurname())
+                            .email(user.getEmail())
+                            .createdAt(user.getCreatedAt())
+                            .isVerified(user.isVerified())
+                            .hasOrders(hasOrders)
+                            .orderCount(orderCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene el ranking de clientes que más han gastado.
+     * <p>
+     * Ordena clientes por la suma total de sus pedidos (totalAmount) en orden
+     * descendente.
+     * Solo incluye usuarios activos y no baneados con al menos un pedido.
+     * </p>
+     *
+     * @param limit Número máximo de clientes a retornar
+     * @return Lista de TopBuyerDTO ordenada por gasto total (descendente)
+     */
+    @Cacheable(value = "topBuyers")
+    public List<TopBuyerDTO> getTopBuyers(int limit) {
+        return userRepository.findAll().stream()
+                .filter(user -> !user.isDeleted() && !user.isBanned())
+                .map(user -> {
+                    List<Order> orders = orderRepository.findAllByUserId(user.getId());
+
+                    double totalSpent = orders.stream()
+                            .mapToDouble(Order::getTotalAmount)
+                            .sum();
+
+                    long orderCount = orders.size();
+
+                    double averageOrderValue = orderCount > 0 ? totalSpent / orderCount : 0.0;
+
+                    return TopBuyerDTO.builder()
+                            .userId(user.getId())
+                            .name(user.getName())
+                            .surname(user.getSurname())
+                            .email(user.getEmail())
+                            .totalSpent(BigDecimal.valueOf(totalSpent))
+                            .orderCount(orderCount)
+                            .averageOrderValue(BigDecimal.valueOf(averageOrderValue))
+                            .build();
+                })
+                .filter(buyer -> buyer.getTotalSpent().compareTo(BigDecimal.ZERO) > 0)
+                .sorted(Comparator.comparing(TopBuyerDTO::getTotalSpent, Comparator.reverseOrder()))
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene la lista de clientes baneados del sistema.
+     * <p>
+     * Retorna todos los usuarios con isBanned = true, ordenados por fecha de
+     * registro.
+     * </p>
+     *
+     * @return Lista de BannedCustomerDTO
+     */
+    @Cacheable(value = "bannedCustomers")
+    public List<BannedCustomerDTO> getBannedCustomers() {
+        return userRepository.findAll().stream()
+                .filter(User::isBanned)
+                .sorted(Comparator.comparing(User::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .map(user -> {
+                    // Contar pedidos del usuario antes del baneo
+                    List<Order> userOrders = orderRepository.findAllByUserId(user.getId());
+                    long orderCount = userOrders.size();
+
+                    return BannedCustomerDTO.builder()
+                            .userId(user.getId())
+                            .name(user.getName())
+                            .surname(user.getSurname())
+                            .email(user.getEmail())
+                            .createdAt(user.getCreatedAt())
+                            .lastLogin(user.getLastLogin())
+                            .orderCount(orderCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene métricas de retención de clientes.
+     * <p>
+     * Calcula:
+     * - Total de clientes registrados
+     * - Clientes con al menos un pedido
+     * - Clientes recurrentes (con más de un pedido)
+     * - Tasa de retención (recurrentes / con pedidos)
+     * - Tasa de conversión (con pedidos / total)
+     * </p>
+     *
+     * @return CustomerRetentionDTO con las métricas calculadas
+     */
+    @Cacheable(value = "customerRetention")
+    public CustomerRetentionDTO getCustomerRetention() {
+        List<User> allUsers = userRepository.findAll().stream()
+                .filter(user -> !user.isDeleted() && !user.isBanned())
+                .collect(Collectors.toList());
+
+        long totalCustomers = allUsers.size();
+
+        // Obtener todos los pedidos y agrupar por usuario
+        Map<Long, Long> orderCounts = orderRepository.findAll().stream()
+                .collect(Collectors.groupingBy(order -> order.getUser().getId(), Collectors.counting()));
+
+        long customersWithOrders = orderCounts.values().stream()
+                .filter(count -> count > 0)
+                .count();
+
+        long recurringCustomers = orderCounts.values().stream()
+                .filter(count -> count > 1)
+                .count();
+
+        Double retentionRate = customersWithOrders > 0 ? (double) recurringCustomers / customersWithOrders * 100 : 0.0;
+
+        Double conversionRate = totalCustomers > 0 ? (double) customersWithOrders / totalCustomers * 100 : 0.0;
+
+        return CustomerRetentionDTO.builder()
+                .totalCustomers(totalCustomers)
+                .customersWithOrders(customersWithOrders)
+                .recurringCustomers(recurringCustomers)
+                .retentionRate(Math.round(retentionRate * 100.0) / 100.0) // 2 decimales
+                .conversionRate(Math.round(conversionRate * 100.0) / 100.0)
+                .build();
+    }
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/service/OrdersDashboardService.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/service/OrdersDashboardService.java
@@ -1,0 +1,221 @@
+package es.marcha.backend.modules.dashboard.application.service;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.marcha.backend.core.shared.domain.enums.OrderStatus;
+import es.marcha.backend.modules.dashboard.application.dto.response.DelayedShipmentDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.OrderQueueItemDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.PendingRefundDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.TodayOrdersSummaryDTO;
+import es.marcha.backend.modules.order.domain.enums.PaymentStatus;
+import es.marcha.backend.modules.order.domain.model.Order;
+import es.marcha.backend.modules.order.infrastructure.persistence.OrderRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Servicio especializado para métricas y operaciones del dashboard de pedidos.
+ * <p>
+ * Proporciona resúmenes, colas de trabajo y alertas relacionadas con pedidos y
+ * pagos.
+ * Todos los métodos están cacheados y son de solo lectura.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrdersDashboardService {
+
+    private final OrderRepository orderRepository;
+
+    /**
+     * Obtiene el resumen de pedidos del día actual.
+     * <p>
+     * Calcula: total de pedidos hoy, ingresos totales, pedidos pendientes y
+     * completados.
+     * </p>
+     *
+     * @return TodayOrdersSummaryDTO con las estadísticas del día
+     */
+    @Cacheable(value = "todayOrdersSummary")
+    public TodayOrdersSummaryDTO getTodayOrdersSummary() {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        List<Order> todayOrders = orderRepository.findAll().stream()
+                .filter(order -> order.getCreatedAt() != null &&
+                        order.getCreatedAt().isAfter(startOfDay) &&
+                        order.getCreatedAt().isBefore(endOfDay))
+                .collect(Collectors.toList());
+
+        long totalOrders = todayOrders.size();
+
+        double totalRevenue = todayOrders.stream()
+                .mapToDouble(Order::getTotalAmount)
+                .sum();
+
+        long pendingOrders = todayOrders.stream()
+                .filter(order -> order.getStatus() == OrderStatus.CREATED ||
+                        order.getStatus() == OrderStatus.PROCESSING)
+                .count();
+
+        long completedOrders = todayOrders.stream()
+                .filter(order -> order.getStatus() == OrderStatus.DELIVERED)
+                .count();
+
+        return TodayOrdersSummaryDTO.builder()
+                .totalOrders(totalOrders)
+                .totalRevenue(BigDecimal.valueOf(totalRevenue))
+                .pendingOrders(pendingOrders)
+                .completedOrders(completedOrders)
+                .build();
+    }
+
+    /**
+     * Obtiene la cola de pedidos pendientes de procesamiento.
+     * <p>
+     * Retorna pedidos en estado CREATED o PROCESSING, ordenados por antigüedad (más
+     * antiguos primero).
+     * </p>
+     *
+     * @param limit Número máximo de pedidos a retornar
+     * @return Lista de OrderQueueItemDTO ordenada por antigüedad
+     */
+    @Cacheable(value = "orderQueue")
+    public List<OrderQueueItemDTO> getOrderQueue(int limit) {
+        List<Order> pendingOrders = orderRepository.findAll().stream()
+                .filter(order -> order.getStatus() == OrderStatus.CREATED ||
+                        order.getStatus() == OrderStatus.PROCESSING)
+                .sorted((o1, o2) -> o1.getCreatedAt().compareTo(o2.getCreatedAt()))
+                .limit(limit)
+                .collect(Collectors.toList());
+
+        return pendingOrders.stream()
+                .map(order -> {
+                    long hoursSinceCreation = order.getCreatedAt() != null
+                            ? Duration.between(order.getCreatedAt(), LocalDateTime.now()).toHours()
+                            : 0;
+
+                    return OrderQueueItemDTO.builder()
+                            .orderId(order.getId())
+                            .status(order.getStatus().name())
+                            .totalAmount(BigDecimal.valueOf(order.getTotalAmount()))
+                            .createdAt(order.getCreatedAt())
+                            .customerName(order.getUser().getName() + " " + order.getUser().getSurname())
+                            .customerEmail(order.getUser().getEmail())
+                            .hoursSinceCreation(hoursSinceCreation)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene la lista de pagos en estado SUCCESS que potencialmente necesitan
+     * reembolso.
+     * <p>
+     * Este método retorna pagos exitosos que podrían requerir procesamiento de
+     * reembolso
+     * en un futuro flujo manual (ej: devoluciones, cancelaciones post-pago).
+     * Nota: Para reembolsos reales, verificar que el pedido esté en estado
+     * RETURNED.
+     * </p>
+     *
+     * @param limit Número máximo de pagos a retornar
+     * @return Lista de PendingRefundDTO
+     */
+    @Cacheable(value = "pendingRefunds")
+    public List<PendingRefundDTO> getPendingRefunds(int limit) {
+        // Obtener pedidos en estado RETURNED que tengan pagos SUCCESS
+        List<Order> ordersNeedingRefund = orderRepository.findAll().stream()
+                .filter(order -> order.getStatus() == OrderStatus.RETURNED)
+                .filter(order -> order.getPayments() != null && !order.getPayments().isEmpty())
+                .filter(order -> order.getPayments().stream()
+                        .anyMatch(payment -> payment.getStatus() == PaymentStatus.SUCCESS))
+                .limit(limit)
+                .collect(Collectors.toList());
+
+        return ordersNeedingRefund.stream()
+                .flatMap(order -> order.getPayments().stream()
+                        .filter(payment -> payment.getStatus() == PaymentStatus.SUCCESS)
+                        .map(payment -> PendingRefundDTO.builder()
+                                .paymentId(payment.getId())
+                                .orderId(order.getId())
+                                .amount(BigDecimal.valueOf(payment.getAmount()))
+                                .paymentMethod(order.getPaymentMethod())
+                                .orderCreatedAt(order.getCreatedAt())
+                                .customerName(order.getUser().getName() + " " + order.getUser().getSurname())
+                                .customerEmail(order.getUser().getEmail())
+                                .stripePaymentIntentId(payment.getTransactionId())
+                                .build()))
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene la lista de pedidos con envíos retrasados.
+     * <p>
+     * Un pedido se considera retrasado si está en estado PROCESSING y han pasado
+     * más de 7 días
+     * desde su creación. La fecha estimada de entrega se calcula como createdAt + 7
+     * días.
+     * </p>
+     *
+     * @param limit Número máximo de pedidos a retornar
+     * @return Lista de DelayedShipmentDTO ordenada por días de retraso
+     *         (descendente)
+     */
+    @Cacheable(value = "delayedShipments")
+    public List<DelayedShipmentDTO> getDelayedShipments(int limit) {
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+
+        List<Order> delayedOrders = orderRepository.findAll().stream()
+                .filter(order -> order.getStatus() == OrderStatus.PROCESSING)
+                .filter(order -> order.getCreatedAt() != null &&
+                        order.getCreatedAt().isBefore(sevenDaysAgo))
+                .collect(Collectors.toList());
+
+        return delayedOrders.stream()
+                .map(order -> {
+                    LocalDateTime estimatedDeliveryDate = order.getCreatedAt().plusDays(7);
+                    long daysDelayed = ChronoUnit.DAYS.between(estimatedDeliveryDate, LocalDateTime.now());
+
+                    // Obtener dirección de envío del primer OrderItem si existe
+                    String shippingAddress = "N/A";
+                    if (order.getOrderItems() != null && !order.getOrderItems().isEmpty()) {
+                        // Obtener dirección del usuario
+                        if (order.getUser() != null && order.getUser().getAddresses() != null &&
+                                !order.getUser().getAddresses().isEmpty()) {
+                            var address = order.getUser().getAddresses().get(0);
+                            shippingAddress = String.format("%s, %s, %s",
+                                    address.getAddressLine1() != null ? address.getAddressLine1() : "",
+                                    address.getCity() != null ? address.getCity() : "",
+                                    address.getPostalCode() != null ? address.getPostalCode() : "");
+                        }
+                    }
+
+                    return DelayedShipmentDTO.builder()
+                            .orderId(order.getId())
+                            .status(order.getStatus().name())
+                            .totalAmount(BigDecimal.valueOf(order.getTotalAmount()))
+                            .createdAt(order.getCreatedAt())
+                            .estimatedDeliveryDate(estimatedDeliveryDate)
+                            .daysDelayed(daysDelayed)
+                            .customerName(order.getUser().getName() + " " + order.getUser().getSurname())
+                            .customerEmail(order.getUser().getEmail())
+                            .shippingAddress(shippingAddress)
+                            .build();
+                })
+                .sorted((d1, d2) -> Long.compare(d2.getDaysDelayed(), d1.getDaysDelayed()))
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/service/StoreDashboardService.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/service/StoreDashboardService.java
@@ -1,0 +1,200 @@
+package es.marcha.backend.modules.dashboard.application.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.marcha.backend.modules.catalog.domain.model.product.Product;
+import es.marcha.backend.modules.catalog.domain.model.product.ProductReview;
+import es.marcha.backend.modules.catalog.infrastructure.persistence.ProductRepository;
+import es.marcha.backend.modules.dashboard.application.dto.response.BestRatedProductDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.MostViewedProductDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.ProductSummaryDTO;
+import es.marcha.backend.modules.dashboard.application.dto.response.RecentReviewDTO;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Servicio especializado para métricas y operaciones del dashboard de
+ * tienda/catálogo.
+ * <p>
+ * Proporciona estadísticas de productos, productos destacados, valoraciones y
+ * reseñas.
+ * Todos los métodos están cacheados y son de solo lectura.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreDashboardService {
+
+    private final ProductRepository productRepository;
+
+    /**
+     * Obtiene el resumen de productos del catálogo.
+     * <p>
+     * Calcula: total de productos, activos, inactivos y sin stock.
+     * </p>
+     *
+     * @return ProductSummaryDTO con los contadores de productos
+     */
+    @Cacheable(value = "productSummary")
+    public ProductSummaryDTO getProductSummary() {
+        List<Product> allProducts = productRepository.findAll();
+
+        long totalProducts = allProducts.size();
+
+        long activeProducts = allProducts.stream()
+                .filter(product -> product.isActive() && !product.isDeleted())
+                .count();
+
+        long inactiveProducts = allProducts.stream()
+                .filter(product -> !product.isActive() && !product.isDeleted())
+                .count();
+
+        long outOfStockProducts = allProducts.stream()
+                .filter(product -> !product.isDeleted() && product.getStock() == 0)
+                .count();
+
+        return ProductSummaryDTO.builder()
+                .totalProducts(totalProducts)
+                .activeProducts(activeProducts)
+                .inactiveProducts(inactiveProducts)
+                .outOfStockProducts(outOfStockProducts)
+                .build();
+    }
+
+    /**
+     * Obtiene los productos más visitados del catálogo.
+     * <p>
+     * Retorna productos ordenados por número de vistas en orden descendente.
+     * Solo incluye productos activos y no eliminados.
+     * </p>
+     *
+     * @param limit Número máximo de productos a retornar
+     * @return Lista de MostViewedProductDTO ordenada por vistas (descendente)
+     */
+    @Cacheable(value = "mostViewedProducts")
+    public List<MostViewedProductDTO> getMostViewedProducts(int limit) {
+        return productRepository.findAll().stream()
+                .filter(product -> product.isActive() && !product.isDeleted())
+                .filter(product -> product.getViews() != null && product.getViews() > 0)
+                .sorted(Comparator.comparing(Product::getViews, Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .map(product -> {
+                    String imageUrl = null;
+                    if (product.getImages() != null && !product.getImages().isEmpty()) {
+                        imageUrl = product.getImages().get(0).getUrl();
+                    }
+
+                    return MostViewedProductDTO.builder()
+                            .productId(product.getId())
+                            .name(product.getName())
+                            .sku(product.getSku())
+                            .price(product.getPrice())
+                            .views(product.getViews() != null ? product.getViews() : 0)
+                            .imageUrl(imageUrl)
+                            .stock(product.getStock())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene los productos mejor valorados del catálogo.
+     * <p>
+     * Retorna productos con el rating promedio más alto, calculado a partir de sus
+     * reviews.
+     * Solo incluye productos activos, no eliminados y con al menos 1 review.
+     * </p>
+     *
+     * @param limit Número máximo de productos a retornar
+     * @return Lista de BestRatedProductDTO ordenada por rating (descendente)
+     */
+    @Cacheable(value = "bestRatedProducts")
+    public List<BestRatedProductDTO> getBestRatedProducts(int limit) {
+        return productRepository.findAll().stream()
+                .filter(product -> product.isActive() && !product.isDeleted())
+                .filter(product -> product.getReviews() != null && !product.getReviews().isEmpty())
+                .filter(product -> product.getReviews().stream().anyMatch(r -> r.isActive() && !r.isDeleted()))
+                .map(product -> {
+                    // Calcular rating promedio de reviews activas
+                    List<ProductReview> activeReviews = product.getReviews().stream()
+                            .filter(review -> review.isActive() && !review.isDeleted())
+                            .collect(Collectors.toList());
+
+                    double averageRating = activeReviews.stream()
+                            .mapToInt(ProductReview::getRating)
+                            .average()
+                            .orElse(0.0);
+
+                    String imageUrl = null;
+                    if (product.getImages() != null && !product.getImages().isEmpty()) {
+                        imageUrl = product.getImages().get(0).getUrl();
+                    }
+
+                    return BestRatedProductDTO.builder()
+                            .productId(product.getId())
+                            .name(product.getName())
+                            .sku(product.getSku())
+                            .price(product.getPrice())
+                            .averageRating(averageRating)
+                            .reviewCount(activeReviews.size())
+                            .imageUrl(imageUrl)
+                            .stock(product.getStock())
+                            .build();
+                })
+                .sorted(Comparator.comparing(BestRatedProductDTO::getAverageRating, Comparator.reverseOrder()))
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene las reseñas más recientes del catálogo.
+     * <p>
+     * Retorna las últimas reseñas creadas, ordenadas por fecha de creación (más
+     * recientes primero).
+     * Solo incluye reviews activas de productos activos.
+     * </p>
+     *
+     * @param limit Número máximo de reseñas a retornar
+     * @return Lista de RecentReviewDTO ordenada por fecha (descendente)
+     */
+    @Cacheable(value = "recentReviews")
+    public List<RecentReviewDTO> getRecentReviews(int limit) {
+        return productRepository.findAll().stream()
+                .filter(product -> product.isActive() && !product.isDeleted())
+                .filter(product -> product.getReviews() != null && !product.getReviews().isEmpty())
+                .flatMap(product -> product.getReviews().stream()
+                        .filter(review -> review.isActive() && !review.isDeleted())
+                        .map(review -> {
+                            String productImageUrl = null;
+                            if (product.getImages() != null && !product.getImages().isEmpty()) {
+                                productImageUrl = product.getImages().get(0).getUrl();
+                            }
+
+                            String userName = "Usuario";
+                            if (review.getUser() != null) {
+                                userName = review.getUser().getName() + " " + review.getUser().getSurname();
+                            }
+
+                            return RecentReviewDTO.builder()
+                                    .reviewId(review.getId())
+                                    .productId(product.getId())
+                                    .productName(product.getName())
+                                    .rating(review.getRating())
+                                    .comment(review.getComment())
+                                    .createdAt(review.getCreatedAt())
+                                    .userName(userName)
+                                    .productImageUrl(productImageUrl)
+                                    .build();
+                        }))
+                .sorted(Comparator.comparing(RecentReviewDTO::getCreatedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/es/marcha/backend/modules/dashboard/application/service/SupportDashboardService.java
+++ b/src/main/java/es/marcha/backend/modules/dashboard/application/service/SupportDashboardService.java
@@ -1,0 +1,89 @@
+package es.marcha.backend.modules.dashboard.application.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import es.marcha.backend.modules.dashboard.application.dto.response.OrderWithIssueDTO;
+import es.marcha.backend.modules.order.domain.enums.PaymentStatus;
+
+import es.marcha.backend.modules.order.infrastructure.persistence.OrderRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Servicio especializado para métricas y operaciones del dashboard de soporte.
+ * <p>
+ * Proporciona información sobre pedidos con problemas, incidencias y casos que
+ * requieren atención.
+ * Todos los métodos están cacheados y son de solo lectura.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SupportDashboardService {
+
+    private final OrderRepository orderRepository;
+
+    /**
+     * Obtiene la lista de pedidos con incidencias o problemas de pago.
+     * <p>
+     * Retorna pedidos que tienen al menos un pago en estado FAILED o REFUNDED,
+     * indicando que requieren atención del equipo de soporte.
+     * </p>
+     *
+     * @param limit Número máximo de pedidos a retornar
+     * @return Lista de OrderWithIssueDTO ordenada por fecha de creación (más
+     *         recientes primero)
+     */
+    @Cacheable(value = "ordersWithIssues")
+    public List<OrderWithIssueDTO> getOrdersWithIssues(int limit) {
+        return orderRepository.findAll().stream()
+                .filter(order -> order.getPayments() != null && !order.getPayments().isEmpty())
+                .filter(order -> {
+                    // Verificar si tiene pagos con problemas
+                    boolean hasProblems = order.getPayments().stream()
+                            .anyMatch(payment -> payment.getStatus() == PaymentStatus.FAILED ||
+                                    payment.getStatus() == PaymentStatus.REFUNDED);
+                    return hasProblems;
+                })
+                .sorted((o1, o2) -> {
+                    if (o2.getCreatedAt() == null)
+                        return -1;
+                    if (o1.getCreatedAt() == null)
+                        return 1;
+                    return o2.getCreatedAt().compareTo(o1.getCreatedAt());
+                })
+                .limit(limit)
+                .map(order -> {
+                    // Contar items del pedido
+                    int itemCount = order.getOrderItems() != null ? order.getOrderItems().size() : 0;
+
+                    // Verificar tipos de problemas
+                    boolean hasFailedPayments = order.getPayments().stream()
+                            .anyMatch(payment -> payment.getStatus() == PaymentStatus.FAILED);
+
+                    boolean hasRefundedPayments = order.getPayments().stream()
+                            .anyMatch(payment -> payment.getStatus() == PaymentStatus.REFUNDED);
+
+                    return OrderWithIssueDTO.builder()
+                            .orderId(order.getId())
+                            .status(order.getStatus().name())
+                            .totalAmount(BigDecimal.valueOf(order.getTotalAmount()))
+                            .createdAt(order.getCreatedAt())
+                            .customerName(order.getUser().getName() + " " + order.getUser().getSurname())
+                            .customerEmail(order.getUser().getEmail())
+                            .customerPhone(order.getUser().getPhone())
+                            .itemCount(itemCount)
+                            .hasFailedPayments(hasFailedPayments)
+                            .hasRefundedPayments(hasRefundedPayments)
+                            .userId(order.getUser().getId())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Descripción

Segunda parte de Issue #115: Servicios especializados y reglas de seguridad por rol.

## Cambios

✅ **4 Servicios creados** (715 líneas):

### OrdersDashboardService (221 líneas)
- getTodayOrdersSummary() - Resumen de pedidos del día (total, ingresos, pendientes, completados)
- getOrderQueue(limit) - Cola de pedidos CREATED/PROCESSING ordenados por antigüedad
- getPendingRefunds(limit) - Pagos SUCCESS que necesitan reembolso manual
- getDelayedShipments(limit) - Pedidos PROCESSING con +7 días desde creación

### StoreDashboardService (200 líneas)
- getProductSummary() - Contadores de productos (activos/inactivos/sin stock/total)
- getMostViewedProducts(limit) - Productos ordenados por views DESC
- getBestRatedProducts(limit) - Productos con mejor rating promedio (min 1 review)
- getRecentReviews(limit) - Últimas reseñas ordenadas por fecha

### CustomersDashboardService (205 líneas)
- getNewCustomers(period, limit) - Usuarios registrados en período (week/month/quarter/year)
- getTopBuyers(limit) - Clientes ordenados por suma de totalAmount
- getBannedCustomers() - Usuarios con isBanned=true
- getCustomerRetention() - Métricas: total, con pedidos, recurrentes, tasas

### SupportDashboardService (89 líneas)
- getOrdersWithIssues(limit) - Pedidos con pagos FAILED o REFUNDED

✅ **SecurityConfig actualizado** (+14 líneas):
- /dashboard/orders/** → hasRole('ORDERS')
- /dashboard/store/** → hasRole('STORE')
- /dashboard/customers/** → hasRole('CUSTOMERS_INVOICES')
- /dashboard/support/** → hasRole('SUPPORT')
- /dashboard/** → hasAnyRole('SUPER_ADMIN', 'ADMIN') (fallback)

## Características técnicas

✔️ Todos los métodos incluyen:
- @Transactional(readOnly = true) - Operaciones de solo lectura
- @Cacheable con nombres descriptivos - Optimización de rendimiento
- Manejo de casos sin datos - Listas vacías o valores 0
- JavaDoc completo en español

✔️ Seguridad por capas:
- @PreAuthorize en controladores (próximo PR)
- .requestMatchers() en SecurityConfig (este PR)
- Orden específico → genérico para evitar conflictos

## Estrategia de división

Este PR es parte 2 de 3 para mantener bajo el límite de 1000 líneas:
1. **PR #218**: DTOs (746 líneas) ✅ Aprobado
2. **PR #2 (este)**: Servicios + SecurityConfig (729 líneas) ✅
3. **PR #3**: Controladores (305 líneas) ⏳ Pendiente

## Dependencias

⚠️ **Requiere PR #218 aprobado** - Los servicios usan los DTOs creados en el PR anterior.

## Próximos pasos

1. Aprobar PR #218 (DTOs)
2. Aprobar este PR #2
3. Crear PR #3 con los 4 controladores REST

Ref: #115