### PR TITLE
feat(catalog): añadir campo active en DTOs y toggle con cascade en categorías

### DIFF
--- a/src/main/java/es/marcha/backend/modules/catalog/application/dto/response/CategoryResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/dto/response/CategoryResponseDTO.java
@@ -19,5 +19,6 @@ public class CategoryResponseDTO {
     private String name;
     private String description;
     private String slug;
+    private boolean active;
     private List<Subcategory> subcategories;
 }

--- a/src/main/java/es/marcha/backend/modules/catalog/application/dto/response/SubcategoryResponseDTO.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/dto/response/SubcategoryResponseDTO.java
@@ -16,5 +16,5 @@ public class SubcategoryResponseDTO {
     private String name;
     private String description;
     private String slug;
-
+    private boolean active;
 }

--- a/src/main/java/es/marcha/backend/modules/catalog/application/mapper/CategoryMapper.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/mapper/CategoryMapper.java
@@ -10,6 +10,7 @@ public class CategoryMapper {
                 .name(category.getName())
                 .description(category.getDescription())
                 .slug(category.getSlug())
+                .active(category.isActive())
                 .subcategories(category.getSubcategories())
                 .build();
     }

--- a/src/main/java/es/marcha/backend/modules/catalog/application/mapper/SubcategoryMapper.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/mapper/SubcategoryMapper.java
@@ -10,6 +10,7 @@ public class SubcategoryMapper {
                 .name(subcategory.getName())
                 .description(subcategory.getDescription())
                 .slug(subcategory.getSlug())
+                .active(subcategory.isActive())
                 .build();
     }
 

--- a/src/main/java/es/marcha/backend/modules/catalog/application/service/CategoryService.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/service/CategoryService.java
@@ -11,6 +11,7 @@ import es.marcha.backend.core.error.exception.ProductException;
 import es.marcha.backend.modules.catalog.application.mapper.CategoryMapper;
 import es.marcha.backend.modules.catalog.domain.model.Category;
 import es.marcha.backend.modules.catalog.infrastructure.persistence.CategoryRepository;
+import es.marcha.backend.modules.catalog.infrastructure.persistence.SubcategoryRepository;
 import es.marcha.backend.core.shared.utils.ProductUtils;
 import jakarta.transaction.Transactional;
 
@@ -19,8 +20,22 @@ public class CategoryService {
     // Attribs
     @Autowired
     private CategoryRepository catRepository;
+    @Autowired
+    private SubcategoryRepository subcatRepository;
 
     public static final String CATEGORY_DELETED = "CATEGORY WAS DELETED";
+
+    /**
+     * Obtiene todas las categorías (activas e inactivas) para el uso del
+     * backoffice.
+     *
+     * @return Lista de {@link CategoryResponseDTO} con todas las categorías.
+     */
+    public List<CategoryResponseDTO> getAllCategoriesAdmin() {
+        return catRepository.findAll().stream()
+                .map(CategoryMapper::toCategoryDTO)
+                .toList();
+    }
 
     /**
      * Obtiene una categoría activa por su ID.
@@ -113,6 +128,31 @@ public class CategoryService {
             throw new ProductException(ProductException.FAILED_FETCH_CATEGORY);
         }
         return categories;
+    }
+
+    /**
+     * Alterna el estado activo/inactivo de una categoría (soft toggle).
+     * Al desactivar, desactiva también todas sus subcategorías.
+     * Al activar, reactiva también todas sus subcategorías.
+     *
+     * @param id El ID de la categoría.
+     * @return {@link CategoryResponseDTO} con el estado actualizado.
+     * @throws ProductException si la categoría no existe.
+     */
+    @Transactional
+    public CategoryResponseDTO toggleCategoryActive(long id) {
+        Category category = catRepository.findById(id)
+                .orElseThrow(() -> new ProductException(ProductException.FAILED_FETCH_CATEGORY));
+        boolean newActive = !category.isActive();
+        LocalDateTime now = LocalDateTime.now();
+        category.setActive(newActive);
+        category.setUpdatedAt(now);
+        catRepository.saveAndFlush(category); // flush explícito antes de que em.clear() limpie el contexto
+        subcatRepository.updateActiveByCategoryId(id, newActive, now);
+        // Reload para que la respuesta refleje el estado persistido
+        Category saved = catRepository.findById(id)
+                .orElseThrow(() -> new ProductException(ProductException.FAILED_FETCH_CATEGORY));
+        return CategoryMapper.toCategoryDTO(saved);
     }
 
     /**

--- a/src/main/java/es/marcha/backend/modules/catalog/application/service/SubcategoryService.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/application/service/SubcategoryService.java
@@ -165,6 +165,22 @@ public class SubcategoryService {
     }
 
     /**
+     * Alterna el estado activo/inactivo de una subcategoría (soft toggle).
+     *
+     * @param id El ID de la subcategoría.
+     * @return {@link SubcategoryResponseDTO} con el estado actualizado.
+     * @throws ProductException si la subcategoría no existe.
+     */
+    @Transactional
+    public SubcategoryResponseDTO toggleSubcategoryActive(long id) {
+        Subcategory subcategory = subcatRepository.findById(id)
+                .orElseThrow(() -> new ProductException(ProductException.FAILED_FETCH_SUBCATEGORY));
+        subcategory.setActive(!subcategory.isActive());
+        subcategory.setUpdatedAt(LocalDateTime.now());
+        return SubcategoryMapper.toResponseDTO(subcatRepository.save(subcategory));
+    }
+
+    /**
      * Elimina una subcategoría de la base de datos a partir de su ID.
      *
      * Este método busca la subcategoría por el ID proporcionado. Si no se

--- a/src/main/java/es/marcha/backend/modules/catalog/infrastructure/persistence/SubcategoryRepository.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/infrastructure/persistence/SubcategoryRepository.java
@@ -1,6 +1,11 @@
 package es.marcha.backend.modules.catalog.infrastructure.persistence;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import es.marcha.backend.modules.catalog.domain.model.Subcategory;
@@ -8,4 +13,10 @@ import es.marcha.backend.modules.catalog.domain.model.Subcategory;
 @Repository
 public interface SubcategoryRepository extends JpaRepository<Subcategory, Long> {
 
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Subcategory s SET s.isActive = :active, s.updatedAt = :updatedAt WHERE s.category.id = :categoryId")
+    void updateActiveByCategoryId(
+            @Param("categoryId") Long categoryId,
+            @Param("active") boolean active,
+            @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/es/marcha/backend/modules/catalog/presentation/controller/CategoryController.java
+++ b/src/main/java/es/marcha/backend/modules/catalog/presentation/controller/CategoryController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -67,6 +68,42 @@ public class CategoryController {
     public ResponseEntity<CategoryResponseDTO> saveCategory(@RequestBody Category category) {
         CategoryResponseDTO savedCategory = catService.saveCategory(category);
         return new ResponseEntity<>(savedCategory, HttpStatus.CREATED);
+    }
+
+    /**
+     * Obtiene todas las categorías (activas e inactivas) para el backoffice.
+     *
+     * @return {@link ResponseEntity} con la lista completa de
+     *         {@link CategoryResponseDTO}.
+     */
+    @GetMapping("/admin")
+    public ResponseEntity<List<CategoryResponseDTO>> getAllCategoriesAdmin() {
+        List<CategoryResponseDTO> categories = catService.getAllCategoriesAdmin();
+        return new ResponseEntity<>(categories, HttpStatus.OK);
+    }
+
+    /**
+     * Alterna el estado activo/inactivo de una categoría.
+     *
+     * @param id El ID de la categoría.
+     * @return {@link ResponseEntity} con el {@link CategoryResponseDTO}
+     *         actualizado.
+     */
+    @PatchMapping("/{id}/toggle")
+    public ResponseEntity<CategoryResponseDTO> toggleCategory(@PathVariable Long id) {
+        return new ResponseEntity<>(catService.toggleCategoryActive(id), HttpStatus.OK);
+    }
+
+    /**
+     * Alterna el estado activo/inactivo de una subcategoría.
+     *
+     * @param id El ID de la subcategoría.
+     * @return {@link ResponseEntity} con el {@link SubcategoryResponseDTO}
+     *         actualizado.
+     */
+    @PatchMapping("/subcategories/{id}/toggle")
+    public ResponseEntity<SubcategoryResponseDTO> toggleSubcategory(@PathVariable Long id) {
+        return new ResponseEntity<>(subcatService.toggleSubcategoryActive(id), HttpStatus.OK);
     }
 
     /**


### PR DESCRIPTION
## Cambios

### DTOs y Mappers
- \CategoryResponseDTO\: añade campo \ctive\
- \SubcategoryResponseDTO\: añade campo \ctive\
- \CategoryMapper\: mapea \ctive(category.isActive())\
- \SubcategoryMapper\: mapea \ctive(subcategory.isActive())\

### Repositorio
- \SubcategoryRepository\: añade \updateActiveByCategoryId()\ con JPQL bulk update y \@Modifying(clearAutomatically = true)\

### Servicio
- \CategoryService.toggleCategoryActive()\: usa \saveAndFlush()\ para garantizar el flush antes del \em.clear()\ del bulk update; cascada de subcategorías al hacer toggle
- \SubcategoryService\: añade \	oggleSubcategoryActive()\

### Controlador
- \CategoryController\: endpoint \PATCH /{id}/toggle\ y \PATCH /subcategories/{id}/toggle\

## Tests
- 146/146 ✅